### PR TITLE
Update yuna api to v2 with 'include' query parameter

### DIFF
--- a/lib/id_convert.js
+++ b/lib/id_convert.js
@@ -22,7 +22,7 @@ async function mapToKitsuId(fullId) {
 
 async function queryIdMapping(idType, id) {
   const yunaType = idType === 'mal' ? 'myanimelist' : idType;
-  const url = `https://relations.yuna.moe/api/ids?source=${yunaType}&id=${id}`
+  const url = `https://relations.yuna.moe/api/v2/ids?source=${yunaType}&id=${id}&include=kitsu`
   return axios.get(url, { timeout: 30000 })
       .then(response => response.data?.kitsu)
       .then(kitsuId => kitsuId


### PR DESCRIPTION
V2 supports the 'include' query parameter, which I used to limit the returned json to only contain the kitsu ID.

![image](https://github.com/TheBeastLT/stremio-kitsu-anime/assets/34382191/34e167a4-101c-4a87-82ba-8a1021e86b33)

![image](https://github.com/TheBeastLT/stremio-kitsu-anime/assets/34382191/8970cf42-527c-45f6-bb8a-921dfb2ae869)